### PR TITLE
Fix handling of firstname/lastname when provisioning from AD

### DIFF
--- a/powerdnsadmin/models/user.py
+++ b/powerdnsadmin/models/user.py
@@ -370,8 +370,10 @@ class User(db.Model):
                         self.email = ldap_result[0][0][1]['mail'][0].decode(
                             "utf-8")
                     elif LDAP_TYPE == 'ad':
-                        self.firstname = ldap_result[0][0][1]['name'][
+                        self.firstname = ldap_result[0][0][1]['givenName'][
                             0].decode("utf-8")
+                        self.lastname = ldap_result[0][0][1]['sn'][0].decode(
+                            "utf-8")
                         self.email = ldap_result[0][0][1]['userPrincipalName'][
                             0].decode("utf-8")
                 except Exception as e:


### PR DESCRIPTION
Previously provisioning would use LDAP 'cn' as PDA 'firstname', this change will use LDAP 'givenName' and LDAP 'sn' for firstname and lastname

<!--
    Thank you for your interest in contributing to the PowerDNS Admin project! Please note that our contribution
    policy requires that a feature request or bug report be approved and assigned prior to opening a pull request.
    This helps avoid wasted time and effort on a proposed change that we might want to or be able to accept.

    IF YOUR PULL REQUEST DOES NOT REFERENCE AN ISSUE WHICH HAS BEEN ASSIGNED TO YOU, IT WILL BE CLOSED AUTOMATICALLY!

    Please specify your assigned issue number on the line below.
-->
### Fixes: #1234

<!--
    Please include a summary of the proposed changes below.
-->